### PR TITLE
Handle non-callable signal handlers

### DIFF
--- a/pyigtl/comm.py
+++ b/pyigtl/comm.py
@@ -208,6 +208,7 @@ class OpenIGTLinkServer(SocketServer.TCPServer, OpenIGTLinkBase):
         self._close_server()
         # Restore original signal handler
         signal.signal(signum, self._previous_signal_handlers[signum])
+        # Send the signal again (this time the original signal handler will process it)
         os.kill(os.getpid(), signum)
 
     def _close_server(self):

--- a/pyigtl/comm.py
+++ b/pyigtl/comm.py
@@ -206,6 +206,7 @@ class OpenIGTLinkServer(SocketServer.TCPServer, OpenIGTLinkBase):
     def _signal_handler(self, signum, stackframe):
         """Properly close the server if signal is received"""
         self._close_server()
+        # Restore original signal handler
         signal.signal(signum, self._previous_signal_handlers[signum])
         os.kill(os.getpid(), signum)
 

--- a/pyigtl/comm.py
+++ b/pyigtl/comm.py
@@ -7,6 +7,7 @@ Created on Tue Nov  3 19:17:05 2015
 
 import collections
 import logging
+import os
 import signal
 import socket
 import socketserver as SocketServer
@@ -205,7 +206,8 @@ class OpenIGTLinkServer(SocketServer.TCPServer, OpenIGTLinkBase):
     def _signal_handler(self, signum, stackframe):
         """Properly close the server if signal is received"""
         self._close_server()
-        self._previous_signal_handlers[signum](signum, stackframe)
+        signal.signal(signum, self._previous_signal_handlers[signum])
+        os.kill(os.getpid(), signum)
 
     def _close_server(self):
         """Will close connection and shutdown server"""


### PR DESCRIPTION
Fixes the case where the server is killed with `SIGTERM`, raising `TypeError: 'Handlers' object is not callable`

In the `OpenIGTLinkServer` constructor, a custom signal handler is added to handle `SIGTERM` and `SIGINT`. This is done [here](https://github.com/lassoan/pyigtl/blob/master/pyigtl/comm.py#L187). The previous signal handler is also stored. When the custom signal handler is [called](https://github.com/lassoan/pyigtl/blob/master/pyigtl/comm.py#L205), the server is first closed, then the previous signal handler is called (and is assumed to be callable). However, in the case of a `SIGTERM`, the previous / default signal handler is `signal.SIG_DFL`, which is _not_ callable, raising the `TypeError` above.

The fix for this is simple. In the custom signal handler, after closing the server / running any custom code, we simply restore the previous handler by making a call to `signal.signal`. Then, we call `os.kill` on the current `pid`, passing the same signal number.

Below is a self contained example. The below code starts up a subprocess, which starts a server, then spins forever in a while loop. Pressing enter will terminate the server. Without the changes in this branch, the above `TypeError` is raised. With them, it exits cleanly.

```python
from multiprocessing import Process
import pyigtl
import time

def wait_for_message():
    conn = pyigtl.OpenIGTLinkServer(18944)
    print("Waiting for connection")
    while not conn.is_connected():
        time.sleep(0.1)
    print("Connection established")
    i = 0
    while True:
        pass


if __name__ == "__main__":
    p = Process(target=wait_for_message)
    p.start()
    input("Press enter to terminate")
    print("terminating")
    p.terminate()
```

Tested with `python3.8` and `ubuntu 18.04`