### PR TITLE
Check when server stop requested more often

### DIFF
--- a/pyigtl/comm.py
+++ b/pyigtl/comm.py
@@ -244,7 +244,8 @@ class TCPRequestHandler(SocketServer.BaseRequestHandler):
 
             try:
                 while self.server._receive_message_from_socket(self.request):
-                    pass
+                    if self.server.communication_thread_stop_requested:
+                        break
             except Exception as exp:
                 import traceback
                 traceback.print_exc()


### PR DESCRIPTION
Fixes a potential issue where, if the sever is still receiving messages and it receives a shutdown signal, it can take quite some time before shutting down its subthreads. This is because of how often the shutdown signal is checked in the [`TCPRequestHandler.handle()`](https://github.com/lassoan/pyigtl/blob/master/pyigtl/comm.py#L239) method. The variable `communication_thread_stop_requested` is only checked at the top of the loop. If this variable switches to `True` while [`_receive_message_from_socket`](https://github.com/lassoan/pyigtl/blob/master/pyigtl/comm.py#L246) is still running, it can take quite some time before that method returns `False` and the status of the variable is checked.

This PR adds a simple check of `communication_thread_stop_requested` after each time that `_receive_message_from_socket` is called. This closes the server much earlier.

See below python code for an example:
Example server code:
```python
import pyigtl
import time

def wait_for_message():
    conn = pyigtl.OpenIGTLinkServer(18944)
    print("Waiting for connection")
    while not conn.is_connected():
        time.sleep(0.1)
    print("Connection established")
    while True:
        conn.wait_for_message("foo_device", timeout=-1)

if __name__ == "__main__":
    wait_for_message()
```

Example client code:
```python
import pyigtl
import numpy as np

if __name__ == "__main__":
    conn = pyigtl.OpenIGTLinkClient("127.0.0.1", 18944)

    print("client started successfully")
    input('Press Enter to send messages.')

    while True:
        msg = pyigtl.ImageMessage(np.random.rand(512, 512), device_name="foo_device")
        conn.send_message(msg, wait=False)
```

Running the server and client for some time, then hitting `ctrl-c` on the server, results in a long wait time for the server to shutdown. With these changes, it shuts down instantly.

Tested with `python3.8` and `ubuntu 18.04`