### PR TITLE
Implement message type TDATA

### DIFF
--- a/examples/example_position_server.py
+++ b/examples/example_position_server.py
@@ -1,0 +1,31 @@
+"""
+============================
+Position sending server
+============================
+
+Simple application that starts a server that provides a stream of random positions.
+
+"""
+
+import pyigtl  # pylint: disable=import-error
+
+from time import sleep
+import numpy as np
+from math import sin
+
+server = pyigtl.OpenIGTLinkServer(port=18944)
+
+timestep = 0
+while True:
+    if not server.is_connected():
+        # Wait for client to connect
+        sleep(0.1)
+        continue
+
+    # Generate data
+    timestep += 1
+    point = np.random.random(size=3)
+    quaternions = np.random.random(size=4)
+    position_message = pyigtl.PositionMessage(point, quaternions, device_name='Position')
+    server.send_message(position_message, wait=True)
+    # Since we wait until the message is actually sent, the message queue will not be flooded

--- a/pyigtl/__init__.py
+++ b/pyigtl/__init__.py
@@ -23,7 +23,7 @@ Quick Start
 """
 
 from .comm import OpenIGTLinkServer, OpenIGTLinkClient
-from .messages import MessageBase, ImageMessage, TransformMessage, StringMessage, PointMessage, PolyDataMessage
+from .messages import MessageBase, ImageMessage, TransformMessage, StringMessage, PointMessage, PolyDataMessage, PositionMessage
 
 from ._version import __version__, __version_info__
 
@@ -35,6 +35,7 @@ __all__ = ['OpenIGTLinkServer',
            'StringMessage',
            'PointMessage',
            'PolyDataMessage',
+           'PositionMessage',
            '__version__',
            '__version_info__'
            ]

--- a/pyigtl/__init__.py
+++ b/pyigtl/__init__.py
@@ -23,7 +23,7 @@ Quick Start
 """
 
 from .comm import OpenIGTLinkServer, OpenIGTLinkClient
-from .messages import MessageBase, ImageMessage, TransformMessage, StringMessage, PointMessage, PolyDataMessage, PositionMessage
+from .messages import MessageBase, ImageMessage, TransformMessage, StringMessage, PointMessage, PolyDataMessage, PositionMessage, TDataMessage, TDataRecord
 
 from ._version import __version__, __version_info__
 

--- a/pyigtl/messages.py
+++ b/pyigtl/messages.py
@@ -757,10 +757,11 @@ class PositionMessage(MessageBase):
     def __init__(self, positions=None, quaternions=None, names=None, rgba_colors=None, diameters=None, groups=None, owners=None,
                  timestamp=None, device_name=None):
         """
-        positions: 3-element vector (for 1 point) or Nx3 matrix (for N points)
+        :param positions: 3-element vector (for 1 position) or Nx3 matrix (for N positions)
+        :param quaternions: 4-element vector (for 1 position) or Nx4 matrix (for N positions)
         """
         MessageBase.__init__(self, timestamp=timestamp, device_name=device_name)
-        self._message_type = "POINT"
+        self._message_type = "POSITION"
         self.positions = positions
         self.quaternions = quaternions
         self.names = names
@@ -800,7 +801,7 @@ class PositionMessage(MessageBase):
         elif len(string_value_or_array) == point_count:
             return string_value_or_array
         else:
-            raise ValueError(f"Point {label} must be either a string or list of strings with same number of items as positions")
+            raise ValueError(f"Position {label} must be either a string or list of strings with same number of items as positions")
 
     def _get_rgba_property_as_array(self, point_count):
         # rgba (4xN)

--- a/pyigtl/messages.py
+++ b/pyigtl/messages.py
@@ -606,7 +606,7 @@ class PointMessage(MessageBase):
 
         binary_content = b""
         for point_index in range(point_count):
-            binary_content += struct.pack("> 64s", str(name_array[point_index]).encode('utf8'))
+            binary_content += struct.pack("> 64s", name_array[point_index].encode('utf8'))
             binary_content += struct.pack("> 32s", group_array[point_index].encode('utf8'))
             rgba = rgba_array[point_index]
             binary_content += struct.pack("> B B B B", rgba[0], rgba[1], rgba[2], rgba[3])

--- a/pyigtl/messages.py
+++ b/pyigtl/messages.py
@@ -752,6 +752,151 @@ class PolyDataMessage(MessageBase):
         self.attributes = None
 
 
+
+class PositionMessage(MessageBase):
+    def __init__(self, positions=None, quaternions=None, names=None, rgba_colors=None, diameters=None, groups=None, owners=None,
+                 timestamp=None, device_name=None):
+        """
+        positions: 3-element vector (for 1 point) or Nx3 matrix (for N points)
+        """
+        MessageBase.__init__(self, timestamp=timestamp, device_name=device_name)
+        self._message_type = "POINT"
+        self.positions = positions
+        self.quaternions = quaternions
+        self.names = names
+        self.rgba_colors = rgba_colors
+        self.diameters = diameters
+        self.groups = groups
+        self.owners = owners
+        self._valid_message = True
+
+    def content_asstring(self):
+        items = []
+        name_array, group_array, rgba_array, xyz_array, quaternion_array, diameter_array, owner_array = self._get_properties_as_arrays()
+        point_count = len(name_array)
+        for point_index in range(point_count):
+            item = f"Position {point_index+1}: name: '{name_array[point_index]}'"
+            if group_array[point_index]:
+                item += f", group: '{group_array[point_index]}'"
+            xyz = xyz_array[point_index]
+            quaternion = quaternion_array[point_index]
+            item += f", xyz: [{xyz[0]}, {xyz[1]}, {xyz[2]}]"
+            item += f", 0ijk: [{quaternion[0]}, {quaternion[1]}, {quaternion[2]}, {quaternion[3]}]"
+            rgba = rgba_array[point_index]
+            item += f", rgba: [{rgba[0]}, {rgba[1]}, {rgba[2]}, {rgba[3]}]"
+            item += f", diameter: {diameter_array[point_index]}"
+            if owner_array[point_index]:
+                item += f", owner: '{owner_array[point_index]}'"
+            items.append(item)
+
+        return "\n".join(items)
+
+    @staticmethod
+    def _get_string_property_as_array(string_value_or_array, point_count, label):
+        if not string_value_or_array:
+            return [''] * point_count
+        elif isinstance(string_value_or_array, str):
+            return [string_value_or_array] * point_count
+        elif len(string_value_or_array) == point_count:
+            return string_value_or_array
+        else:
+            raise ValueError(f"Point {label} must be either a string or list of strings with same number of items as positions")
+
+    def _get_rgba_property_as_array(self, point_count):
+        # rgba (4xN)
+        if not self.rgba_colors:
+            return [[255, 255, 0, 255]] * point_count
+        else:
+            try:
+                rgba_array = np.array(self.rgba_colors, dtype=np.uint8)
+                if len(rgba_array.shape) == 2 and rgba_array.shape[1] == 4 and rgba_array.shape[0] == point_count:
+                    return rgba_array
+                elif len(rgba_array.shape) == 1 and rgba_array.shape[0] == 4:
+                    # single rgba vector, repeat it point_count times
+                    return np.broadcast_to(rgba_array, (point_count, 4))
+                raise ValueError()
+            except Exception:
+                raise ValueError("Point rgba must be either a vector of 4 integers or a matrix with 4 rows and same of columns as positions")
+
+    def _get_diameter_property_as_array(self, point_count):
+        if not self.diameters:
+            return np.zeros(point_count)
+        else:
+            try:
+                diameter_array = np.array(self.diameters, dtype=np.float32)
+                if len(diameter_array.shape) == 1 and diameter_array.shape[0] == point_count:
+                    return diameter_array
+                elif len(diameter_array.shape) == 0:
+                    # single diameter value, repeat it point_count times
+                    return np.broadcast_to(diameter_array, point_count)
+                raise ValueError()
+            except Exception:
+                raise("Point diameter must be either single float value or a vector with same number as positions")
+
+    def _get_properties_as_arrays(self):
+        # Get number of points from the number of specified point coordinate triplets
+        xyz_array = np.asarray(self.positions, dtype=np.float32)
+        quaternion_array = np.asarray(self.quaternions, dtype=np.float32)
+        point_count = 0
+        if len(xyz_array.shape) == 1:
+            if xyz_array.shape[0] == 3:
+                point_count = 1
+                xyz_array = [xyz_array]
+                quaternion_array = [quaternion_array]
+        elif len(xyz_array.shape) == 2:
+            if xyz_array.shape[1] == 3:
+                point_count = xyz_array.shape[0]
+        if point_count == 0:
+            raise ValueError("Point positions must be 3-element vector or Nx3 matrix")
+
+        name_array = PointMessage._get_string_property_as_array(self.names, point_count, 'names')
+        group_array = PointMessage._get_string_property_as_array(self.groups, point_count, 'groups')
+        owner_array = PointMessage._get_string_property_as_array(self.owners, point_count, 'owners')
+        rgba_array = self._get_rgba_property_as_array(point_count)
+        diameter_array = self._get_diameter_property_as_array(point_count)
+
+        return name_array, group_array, rgba_array, xyz_array, quaternion_array, diameter_array, owner_array
+
+    def _pack_content(self):
+        name_array, group_array, rgba_array, xyz_array, quaternion_array, diameter_array, owner_array = self._get_properties_as_arrays()
+        point_count = len(name_array)
+
+        binary_content = b""
+        for point_index in range(point_count):
+            binary_content += struct.pack("> 64s", name_array[point_index].encode('utf8'))
+            binary_content += struct.pack("> 32s", group_array[point_index].encode('utf8'))
+            rgba = rgba_array[point_index]
+            binary_content += struct.pack("> B B B B", rgba[0], rgba[1], rgba[2], rgba[3])
+            xyz = xyz_array[point_index]
+            binary_content += struct.pack("> f f f", xyz[0], xyz[1], xyz[2])
+            quaternion = quaternion_array[point_index]
+            binary_content += struct.pack("> f f f f", quaternion[0], quaternion[1], quaternion[2], quaternion[3])
+            binary_content += struct.pack("> f", diameter_array[point_index])
+            binary_content += struct.pack("> 20s", owner_array[point_index].encode('utf8'))
+        return binary_content
+
+    def _unpack_content(self, content):
+        self.positions = []
+        self.names = []
+        self.rgba_colors = []
+        self.diameters = []
+        self.groups = []
+        self.owners = []
+        s = struct.Struct('> 64s 32s B B B B f f f f 20s')
+        item_length = 64 + 32 + 4 + 4 * 3 + 4 + 20
+        point_count = int(len(content)/item_length)
+        for point_index in range(point_count):
+            values = s.unpack(content[point_index*item_length:(point_index+1)*item_length])
+            self.names.append(values[0].decode().rstrip(' \t\r\n\0'))
+            self.groups.append(values[1].decode().rstrip(' \t\r\n\0'))
+            self.rgba_colors.append((values[2], values[3], values[4], values[5]))
+            self.positions.append((values[6], values[7], values[8]))
+            self.quaternions.append((values[9], values[10], values[11]))
+            self.diameters.append(values[12])
+            self.owners.append(values[13].decode().rstrip(' \t\r\n\0'))
+
+
+
 # http://slicer-devel.65872.n3.nabble.com/OpenIGTLinkIF-and-CRC-td4031360.html
 CRC64 = crcmod.mkCrcFun(0x142F0E1EBA9EA3693, rev=False, initCrc=0x0000000000000000, xorOut=0x0000000000000000)
 
@@ -789,4 +934,5 @@ message_type_to_class_constructor = {
         "IMAGE": ImageMessage,
         "STRING": StringMessage,
         "POINT": PointMessage,
+        "POSITION": PositionMessage,
     }

--- a/pyigtl/tests/test_basic_comm.py
+++ b/pyigtl/tests/test_basic_comm.py
@@ -69,12 +69,15 @@ class TestMessageTypes(unittest.TestCase):
     def test_send_receive(self):
         device_name = "Test"
 
+        M_4x4 = np.eye(4)
+
         test_messages = [
             pyigtl.StringMessage("some message", device_name=device_name),
             pyigtl.ImageMessage(np.random.randn(30, 10, 5) * 50 + 100, device_name=device_name),
             pyigtl.PointMessage([[20, 30, 10], [2, -5, -10], [12.4, 11.3, 0.3]], device_name=device_name),
-            pyigtl.TransformMessage(np.eye(4), device_name=device_name),
+            pyigtl.TransformMessage(M_4x4, device_name=device_name),
             pyigtl.PositionMessage([[1, 2, 3], [4, 5, 6]], [[1, 2, 3, 4], [5, 6, 7, 8]], device_name=device_name),
+            pyigtl.TDataMessage([pyigtl.TDataRecord(M_4x4)], device_name=device_name),
         ]
 
         for message in test_messages:
@@ -84,12 +87,15 @@ class TestMessageTypes(unittest.TestCase):
     def test_pack_unpack(self):
         device_name = "Test"
 
+        M_4x4 = np.eye(4)
+
         test_messages = [
             pyigtl.StringMessage("some message", device_name=device_name),
             pyigtl.ImageMessage(np.random.randn(30, 10, 5)*50+100, device_name=device_name),
             pyigtl.PointMessage([[20, 30, 10], [2, -5, -10], [12.4, 11.3, 0.3]], device_name=device_name),
-            pyigtl.TransformMessage(np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [0, 0, 0, 1]]), device_name=device_name),
+            pyigtl.TransformMessage(M_4x4, device_name=device_name),
             pyigtl.PositionMessage([[1, 2, 3], [4, 5, 6]], [[1, 2, 3, 4], [5, 6, 7, 8]], device_name=device_name),
+            pyigtl.TDataMessage([pyigtl.TDataRecord(M_4x4)], device_name=device_name),
         ]
 
         pack_unpack_inconsistencies_found = 0

--- a/pyigtl/tests/test_basic_comm.py
+++ b/pyigtl/tests/test_basic_comm.py
@@ -74,6 +74,7 @@ class TestMessageTypes(unittest.TestCase):
             pyigtl.ImageMessage(np.random.randn(30, 10, 5) * 50 + 100, device_name=device_name),
             pyigtl.PointMessage([[20, 30, 10], [2, -5, -10], [12.4, 11.3, 0.3]], device_name=device_name),
             pyigtl.TransformMessage(np.eye(4), device_name=device_name),
+            pyigtl.PositionMessage([[1, 2, 3], [4, 5, 6]], [[1, 2, 3, 4], [5, 6, 7, 8]], device_name=device_name),
         ]
 
         for message in test_messages:
@@ -88,16 +89,17 @@ class TestMessageTypes(unittest.TestCase):
             pyigtl.ImageMessage(np.random.randn(30, 10, 5)*50+100, device_name=device_name),
             pyigtl.PointMessage([[20, 30, 10], [2, -5, -10], [12.4, 11.3, 0.3]], device_name=device_name),
             pyigtl.TransformMessage(np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [0, 0, 0, 1]]), device_name=device_name),
+            pyigtl.PositionMessage([[1, 2, 3], [4, 5, 6]], [[1, 2, 3, 4], [5, 6, 7, 8]], device_name=device_name),
         ]
 
         pack_unpack_inconsistencies_found = 0
         for message in test_messages:
-            print("Original message:\n"+str(message))
+            print(f"Original message:\n{message}")
             packed = message.pack()
             header_fields = pyigtl.MessageBase.parse_header(packed[:pyigtl.MessageBase.IGTL_HEADER_SIZE])
             new_message = pyigtl.MessageBase.create_message(header_fields['message_type'])
             new_message.unpack(header_fields, packed[pyigtl.MessageBase.IGTL_HEADER_SIZE:])
-            print("Packed/unpacked message:\n"+str(new_message))
+            print(f"Packed/unpacked message:\n{new_message}")
             new_packed = new_message.pack()
             if packed == new_packed:
                 print(" -- Correct")


### PR DESCRIPTION
This PR implements the first composite message type, namely TDATA. In the API, the message object is constructed by creating a TDataMessage-type object, supplying an iterable (e.g. list) of TDataRecord objects in the constructor.

The code has been successfully tested with the unit test file, but a test with the OpenIGTLink reference implementation still needs to be done.